### PR TITLE
PHP 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ matrix:
       env:
         - COVERAGE=1
     - php: 7.3
+    - php: 7.4
+    - php: 8.0
 
 install:
   - if [ $COVERAGE = "1" ]; then composer require --dev satooshi/php-coveralls; fi
@@ -21,7 +23,8 @@ script:
   - vendor/bin/phpcs --standard=PSR2 src
   - vendor/bin/phpstan analyze src -l max
   - vendor/bin/psalm
-  - vendor/bin/composer-require-checker check --config-file crc-config.json
+  # FIXME: can be enabled once maglnet/composer-require-checker is available on PHP 8.0
+  # - vendor/bin/composer-require-checker check --config-file crc-config.json
   - if [ $COVERAGE = "1" ]; then mkdir -p build/logs && vendor/bin/kahlan --clover=build/logs/clover.xml; fi
 
 after_success:

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.1|^8.0",
         "webmozart/assert": "^1.3"
     },
     "autoload": {
@@ -23,12 +23,11 @@
         ]
     },
     "require-dev": {
-        "ext-json": "^1.5",
-        "maglnet/composer-require-checker": "^1.1",
+        "ext-json": "*",
         "kahlan/kahlan": "^4.3",
         "squizlabs/php_codesniffer": "^3.4",
-        "phpstan/phpstan": "^0.11",
-        "phpstan/phpstan-strict-rules": "^0.11.0",
-        "vimeo/psalm": "^3.2"
+        "phpstan/phpstan": "^0.12",
+        "phpstan/phpstan-strict-rules": "^0.12",
+        "vimeo/psalm": "^3.2|^4.0|dev-master"
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,9 +1,14 @@
 parameters:
+    checkMissingIterableValueType: false
     ignoreErrors:
-        - message: '#Construct empty()#'
+        - message: '#Construct empty\(\)#'
           path: src/Basic/NonEmpty.php
         - message: '#PHPDoc tag @param#'
           path: src/Result/functions.php
+        - message: '#Unsafe usage of new static\(\)#'
+          path: src/Basic/Compare.php
+        - message: '#Unsafe usage of new static\(\)#'
+          path: src/Basic/ComposingAssertion.php
 
 includes:
 	- vendor/phpstan/phpstan-strict-rules/rules.neon

--- a/src/Basic/Compare.php
+++ b/src/Basic/Compare.php
@@ -7,9 +7,6 @@ namespace Marcosh\PhpValidationDSL\Basic;
 use Marcosh\PhpValidationDSL\Result\ValidationResult;
 use Marcosh\PhpValidationDSL\Translator\Translator;
 
-/**
- * @template B
- */
 abstract class Compare
 {
     public const MESSAGE = 'composing-bound.not-respecting-bound';
@@ -17,12 +14,11 @@ abstract class Compare
     /** @var mixed could be any comparable type */
     protected $comparisonBasis;
 
-    /**
-     * @var callable with signature $comparisonBasis -> $data -> string[]
-     */
+    /** @var callable with signature $comparisonBasis -> $data -> string[] */
     private $errorFormatter;
 
     /**
+     * @psalm-template B
      * @param mixed $comparisonBasis
      * @psalm-param B $comparisonBasis
      * @param callable $errorFormatter
@@ -34,6 +30,7 @@ abstract class Compare
     }
 
     /**
+     * @psalm-template B
      * @psalm-param B $comparisonBasis
      * @param mixed $comparisonBasis
      * @return Compare
@@ -51,13 +48,13 @@ abstract class Compare
              * @psalm-return array{0:mixed}
              */
             function ($comparisonBasis, $data): array {
-
                 return [static::MESSAGE];
             }
         );
     }
 
     /**
+     * @psalm-template B
      * @param mixed $comparisonBasis
      * @psalm-param B $comparisonBasis
      * @param callable $errorFormatter
@@ -65,10 +62,12 @@ abstract class Compare
      */
     public static function withBoundAndFormatter($comparisonBasis, callable $errorFormatter): self
     {
+        /** @psalm-suppress UnsafeInstantiation */
         return new static($comparisonBasis, $errorFormatter);
     }
 
     /**
+     * @psalm-template B
      * @param mixed $comparisonBasis
      * @psalm-param B $comparisonBasis
      * @param Translator $translator
@@ -100,6 +99,7 @@ abstract class Compare
     abstract public function validate($data, array $context = []): ValidationResult;
 
     /**
+     * @psalm-template B
      * @param callable $assertion
      * @psalm-param callable(B, B):bool $assertion
      * @param mixed $data

--- a/src/Basic/ComposingAssertion.php
+++ b/src/Basic/ComposingAssertion.php
@@ -8,16 +8,11 @@ use Marcosh\PhpValidationDSL\Result\ValidationResult;
 use Marcosh\PhpValidationDSL\Translator\Translator;
 use function is_callable;
 
-/**
- * @template T
- */
 abstract class ComposingAssertion
 {
     public const MESSAGE = 'composing-assertion.not-as-asserted';
 
-    /**
-     * @var callable|null with signature $data -> string[]
-     */
+    /** @var callable|null with signature $data -> string[] */
     private $errorFormatter;
 
     public function __construct(?callable $errorFormatter = null)
@@ -27,13 +22,16 @@ abstract class ComposingAssertion
 
     public static function withFormatter(callable $errorFormatter): self
     {
+        /** @psalm-suppress UnsafeInstantiation */
         return new static($errorFormatter);
     }
 
     public static function withTranslator(Translator $translator): self
     {
+        /** @psalm-suppress UnsafeInstantiation */
         return new static(
             /**
+             * @psalm-template T
              * @param mixed $data
              * @psalm-param T $data
              * @return string[]
@@ -46,6 +44,7 @@ abstract class ComposingAssertion
     }
 
     /**
+     * @psalm-template T
      * @param mixed $data
      * @psalm-param T $data
      * @param array $context
@@ -54,6 +53,7 @@ abstract class ComposingAssertion
     abstract public function validate($data, array $context = []): ValidationResult;
 
     /**
+     * @psalm-template T
      * @param callable $assertion
      * @param mixed $data
      * @psalm-param T $data

--- a/src/Combinator/Associative.php
+++ b/src/Combinator/Associative.php
@@ -67,7 +67,7 @@ final class Associative implements Validation
                          * @param array $messages
                          * @return array
                          */
-                        static function (array $messages) use ($key) {
+                        static function (array $messages) use ($key): array {
                             return [$key => $messages];
                         }
                     );

--- a/src/Combinator/TranslateErrors.php
+++ b/src/Combinator/TranslateErrors.php
@@ -12,14 +12,10 @@ use function is_string;
 
 final class TranslateErrors implements Validation
 {
-    /**
-     * @var Validation
-     */
+    /** @var Validation */
     private $validation;
 
-    /**
-     * @var Translator
-     */
+    /** @var Translator */
     private $translator;
 
     public function __construct(Validation $validation, Translator $translator)
@@ -44,9 +40,9 @@ final class TranslateErrors implements Validation
 
         return array_map(
             /**
-             * @template T
+             * @psalm-template T
              * @psalm-param T $message
-             * @return T
+             * @psalm-return T|string
              */
             function ($message) use ($translator) {
                 if (is_string($message)) {


### PR DESCRIPTION
- [x] allow installation on PHP 8.0,
- [x] enable PHP 7.4 and 8.0 in Travis jobs,
- [x] removed dev-dependency on `maglnet/composer-require-checker`,
- [x] bumped PHPStan to 0.12,
- [x] allowed Psalm 4.x (and `dev-master` due to https://github.com/vimeo/psalm/issues/4961).